### PR TITLE
Compute on interfaces

### DIFF
--- a/RefraSin.ParticleModel.Test/GeometryTest.cs
+++ b/RefraSin.ParticleModel.Test/GeometryTest.cs
@@ -1,0 +1,113 @@
+using RefraSin.Coordinates.Polar;
+using static NUnit.Framework.Assert;
+using static RefraSin.Coordinates.Constants;
+
+namespace RefraSin.ParticleModel.Test;
+
+[TestFixture]
+public class GeometryTest
+{
+    record DummyNode(Guid Id, Guid ParticleId, PolarPoint Coordinates, NodeType Type, INode Upper, INode Lower) : INodeGeometry
+    {
+        public IParticle Particle => throw new NotImplementedException();
+    }
+
+    [Test]
+    public void TestAngleDistance()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Surface, upper, lower);
+
+        That((double)node.AngleDistance.ToUpper, Is.EqualTo(QuarterOfPi).Within(1e-8));
+        That((double)node.AngleDistance.ToLower, Is.EqualTo(QuarterOfPi + ThirdOfPi).Within(1e-8));
+    }
+
+    [Test]
+    public void TestSurfaceDistance()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Surface, upper, lower);
+
+        That(node.SurfaceDistance.ToUpper, Is.EqualTo(0.7368).Within(1e-4));
+        That(node.SurfaceDistance.ToLower, Is.EqualTo(1.5867).Within(1e-4));
+    }
+
+    [Test]
+    public void TestSurfaceRadiusAngle()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Surface, upper, lower);
+
+        That((double)node.SurfaceRadiusAngle.ToUpper, Is.EqualTo(0.50047).Within(1e-4));
+        That((double)node.SurfaceRadiusAngle.ToLower, Is.EqualTo((Pi - QuarterOfPi - ThirdOfPi) / 2).Within(1e-8));
+    }
+
+    [Test]
+    public void TestVolume()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Surface, upper, lower);
+
+        That(node.Volume.ToUpper, Is.EqualTo(0.17677).Within(1e-4));
+        That(node.Volume.ToLower, Is.EqualTo(0.48296).Within(1e-4));
+    }
+
+    [Test]
+    public void TestSurfaceNormalAngle()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Surface, upper, lower);
+
+        That((double)node.SurfaceNormalAngle.ToUpper, Is.EqualTo(2.564106).Within(1e-4));
+        That(node.SurfaceNormalAngle.ToLower, Is.EqualTo(node.SurfaceNormalAngle.ToUpper).Within(1e-8));
+    }
+
+    [Test]
+    public void TestSurfaceNormalAngleNeckLowerIsGrainBoundary()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.GrainBoundary);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Neck, upper, lower);
+
+        That((double)node.SurfaceNormalAngle.ToUpper, Is.EqualTo(2.564106 * 2 - HalfOfPi).Within(1e-4));
+        That((double)node.SurfaceNormalAngle.ToLower, Is.EqualTo(HalfOfPi).Within(1e-8));
+    }
+
+    [Test]
+    public void TestSurfaceNormalAngleNeckUpperIsGrainBoundary()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.GrainBoundary);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Neck, upper, lower);
+
+        That((double)node.SurfaceNormalAngle.ToLower, Is.EqualTo(2.564106 * 2 - HalfOfPi).Within(1e-4));
+        That((double)node.SurfaceNormalAngle.ToUpper, Is.EqualTo(HalfOfPi).Within(1e-8));
+    }
+
+    [Test]
+    public void TestSurfaceTangentAngleNeckLowerIsGrainBoundary()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.Surface);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.GrainBoundary);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Neck, upper, lower);
+
+        That((double)node.SurfaceTangentAngle.ToUpper, Is.EqualTo(2.564106 * 2 - Pi).Within(1e-4));
+        That((double)node.SurfaceTangentAngle.ToLower, Is.EqualTo(0).Within(1e-8));
+    }
+
+    [Test]
+    public void TestSurfaceTangentAngleNeckUpperIsGrainBoundary()
+    {
+        var upper = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(HalfOfPi, 0.5), NodeType.GrainBoundary);
+        var lower = new Node(Guid.NewGuid(), Guid.Empty, new PolarPoint(-ThirdOfPi, 1), NodeType.Surface);
+        INodeGeometry node = new DummyNode(Guid.NewGuid(), Guid.Empty, new PolarPoint(QuarterOfPi, 1), NodeType.Neck, upper, lower);
+
+        That((double)node.SurfaceTangentAngle.ToLower, Is.EqualTo(2.564106 * 2 - Pi).Within(1e-4));
+        That((double)node.SurfaceTangentAngle.ToUpper, Is.EqualTo(0).Within(1e-8));
+    }
+}

--- a/RefraSin.ParticleModel/GrainBoundaryNode.cs
+++ b/RefraSin.ParticleModel/GrainBoundaryNode.cs
@@ -9,7 +9,7 @@ namespace RefraSin.ParticleModel;
 /// </summary>
 public record GrainBoundaryNode(
     Guid Id,
-    Guid ParticleId,
+    IParticle Particle,
     PolarPoint Coordinates,
     Guid ContactedParticleId,
     Guid ContactedNodeId,
@@ -30,12 +30,12 @@ public record GrainBoundaryNode(
     NormalTangential<Angle> CenterShiftVectorDirection,
     NormalTangential<double> ContactDistanceGradient,
     NormalTangential<double> ContactDirectionGradient
-) : Node(Id, ParticleId, Coordinates, NodeType.GrainBoundaryNode), IGrainBoundaryNode
+) : Node(Id, Particle.Id, Coordinates, NodeType.GrainBoundary), IGrainBoundaryNode
 {
     public GrainBoundaryNode(IGrainBoundaryNode template)
         : this(
             template.Id,
-            template.ParticleId,
+            template.Particle,
             template.Coordinates,
             template.ContactedParticleId,
             template.ContactedNodeId,

--- a/RefraSin.ParticleModel/INodeGeometry.cs
+++ b/RefraSin.ParticleModel/INodeGeometry.cs
@@ -3,40 +3,40 @@ using RefraSin.Coordinates.Absolute;
 
 namespace RefraSin.ParticleModel;
 
-public interface INodeGeometry
+public interface INodeGeometry : INodeNeighbors
 {
     /// <summary>
     /// Absolute coordinates.
     /// </summary>
-    public AbsolutePoint AbsoluteCoordinates { get; }
+    public AbsolutePoint AbsoluteCoordinates => Coordinates.Absolute;
 
     /// <summary>
     /// Length of the surface lines to neighbor nodes.
     /// </summary>
-    public ToUpperToLower<double> SurfaceDistance { get; }
+    public ToUpperToLower<double> SurfaceDistance => this.SurfaceDistance();
 
     /// <summary>
     /// Angle between radial vector and surface line.
     /// </summary>
-    public ToUpperToLower<Angle> SurfaceRadiusAngle { get; }
+    public ToUpperToLower<Angle> SurfaceRadiusAngle => this.SurfaceRadiusAngle();
 
     /// <summary>
     /// Angle distance to neighbor nodes.
     /// </summary>
-    public ToUpperToLower<Angle> AngleDistance { get; }
+    public ToUpperToLower<Angle> AngleDistance => this.AngleDistance();
 
     /// <summary>
     /// Volume of the adjacent elements.
     /// </summary>
-    public ToUpperToLower<double> Volume { get; }
+    public ToUpperToLower<double> Volume => this.Volume();
 
     /// <summary>
     /// Angle between surface line and surface normal resp. tangent.
     /// </summary>
-    public ToUpperToLower<Angle> SurfaceNormalAngle { get; }
-    
+    public ToUpperToLower<Angle> SurfaceNormalAngle => this.SurfaceNormalAngle();
+
     /// <summary>
     /// Angle between surface line and surface normal resp. tangent.
     /// </summary>
-    public ToUpperToLower<Angle> SurfaceTangentAngle { get; }
+    public ToUpperToLower<Angle> SurfaceTangentAngle => this.SurfaceTangentAngle();
 }

--- a/RefraSin.ParticleModel/INodeNeighbors.cs
+++ b/RefraSin.ParticleModel/INodeNeighbors.cs
@@ -1,16 +1,16 @@
 namespace RefraSin.ParticleModel;
 
-public interface INodeNeighbors
+public interface INodeNeighbors : INode
 {
     /// <summary>
     /// Upper neighbor of this node.
     /// </summary>
-    public INode Upper { get; }
+    public INode Upper => Particle.Nodes.UpperNeighborOf(this);
 
     /// <summary>
     /// Lower neighbor of this node.
     /// </summary>
-    public INode Lower { get; }
+    public INode Lower => Particle.Nodes.LowerNeighborOf(this);
 
     /// <summary>
     /// Particle this node belongs to.

--- a/RefraSin.ParticleModel/IParticle.cs
+++ b/RefraSin.ParticleModel/IParticle.cs
@@ -24,5 +24,5 @@ public interface IParticle : IVertex
     /// <summary>
     /// List of node specs.
     /// </summary>
-    public IReadOnlyParticleSurface<INode> Nodes { get; }
+    public IReadOnlyParticleSurface<INodeGeometry> Nodes { get; }
 }

--- a/RefraSin.ParticleModel/IReadOnlyParticleSurface.cs
+++ b/RefraSin.ParticleModel/IReadOnlyParticleSurface.cs
@@ -21,4 +21,16 @@ public interface IReadOnlyParticleSurface<out TNode> : IReadOnlyNodeCollection<T
     /// <param name="start">start ID</param>
     /// <param name="end">end ID (inclusive)</param>
     public IReadOnlyList<TNode> this[Guid start, Guid end] { get; }
+
+    /// <summary>
+    /// Returns the node that is the first upper neighbor of the specified one in the surface.
+    /// </summary>
+    /// <param name="node"></param>
+    public INode UpperNeighborOf(INode node) => this[IndexOf(node.Id) + 1];
+
+    /// <summary>
+    /// Returns the node that is the first lower neighbor of the specified one in the surface.
+    /// </summary>
+    /// <param name="node"></param>
+    public INode LowerNeighborOf(INode node) => this[IndexOf(node.Id) - 1];
 }

--- a/RefraSin.ParticleModel/NeckNode.cs
+++ b/RefraSin.ParticleModel/NeckNode.cs
@@ -9,7 +9,7 @@ namespace RefraSin.ParticleModel;
 /// </summary>
 public record NeckNode(
     Guid Id,
-    Guid ParticleId,
+    IParticle Particle,
     PolarPoint Coordinates,
     Guid ContactedParticleId,
     Guid ContactedNodeId,
@@ -30,12 +30,12 @@ public record NeckNode(
     NormalTangential<Angle> CenterShiftVectorDirection,
     NormalTangential<double> ContactDistanceGradient,
     NormalTangential<double> ContactDirectionGradient
-) : Node(Id, ParticleId, Coordinates, NodeType.NeckNode), INeckNode
+) : Node(Id, Particle.Id, Coordinates, NodeType.Neck), INeckNode
 {
     public NeckNode(INeckNode template)
         : this(
             template.Id,
-            template.ParticleId,
+            template.Particle,
             template.Coordinates,
             template.ContactedParticleId,
             template.ContactedNodeId,

--- a/RefraSin.ParticleModel/NodeGeometry.cs
+++ b/RefraSin.ParticleModel/NodeGeometry.cs
@@ -1,0 +1,11 @@
+using RefraSin.Coordinates.Polar;
+
+namespace RefraSin.ParticleModel;
+
+public record NodeGeometry(Guid Id, IParticle Particle, PolarPoint Coordinates, NodeType Type)
+    : Node(Id, Particle.Id, Coordinates, Type), INodeGeometry
+{
+    public NodeGeometry(INodeGeometry template) : this(template.Id, template.Particle, template.Coordinates, template.Type) { }
+    
+    public NodeGeometry(INode template, IParticle particle) : this(template.Id, particle, template.Coordinates, template.Type) { }
+}

--- a/RefraSin.ParticleModel/NodeGeometryExtensions.cs
+++ b/RefraSin.ParticleModel/NodeGeometryExtensions.cs
@@ -1,0 +1,42 @@
+using RefraSin.Coordinates;
+using RefraSin.Coordinates.Helpers;
+using static System.Math;
+
+namespace RefraSin.ParticleModel;
+
+public static class NodeGeometryExtensions
+{
+    public static ToUpperToLower<double> SurfaceDistance(this INodeGeometry self) => new(
+        CosLaw.C(self.Upper.Coordinates.R, self.Coordinates.R,
+            self.AngleDistance
+                .ToUpper),
+        CosLaw.C(self.Lower.Coordinates.R, self.Coordinates.R, self.AngleDistance.ToLower)
+    );
+
+    public static ToUpperToLower<Angle> AngleDistance(this INodeGeometry self) => new(
+        self.Coordinates.AngleTo(self.Upper.Coordinates),
+        self.Coordinates.AngleTo(self.Lower.Coordinates)
+    );
+
+    public static ToUpperToLower<Angle> SurfaceRadiusAngle(this INodeGeometry self) => new(
+        CosLaw.Gamma(self.SurfaceDistance.ToUpper, self.Coordinates.R, self.Upper.Coordinates.R),
+        CosLaw.Gamma(self.SurfaceDistance.ToLower, self.Coordinates.R, self.Lower.Coordinates.R)
+    );
+
+    public static ToUpperToLower<double> Volume(this INodeGeometry self) => new(
+        0.5 * self.Coordinates.R * self.Upper.Coordinates.R * Sin(self.AngleDistance.ToUpper),
+        0.5 * self.Coordinates.R * self.Lower.Coordinates.R * Sin(self.AngleDistance.ToLower)
+    );
+
+    public static ToUpperToLower<Angle> SurfaceNormalAngle(this INodeGeometry self)
+    {
+        var angle = PI - 0.5 * (self.SurfaceRadiusAngle.ToUpper + self.SurfaceRadiusAngle.ToLower);
+        return new ToUpperToLower<Angle>(angle, angle);
+    }
+
+    public static ToUpperToLower<Angle> SurfaceTangentAngle(this INodeGeometry self)
+    {
+        var angle = PI / 2 - 0.5 * (self.SurfaceRadiusAngle.ToUpper + self.SurfaceRadiusAngle.ToLower);
+        return new ToUpperToLower<Angle>(angle, angle);
+    }
+}

--- a/RefraSin.ParticleModel/NodeGeometryExtensions.cs
+++ b/RefraSin.ParticleModel/NodeGeometryExtensions.cs
@@ -33,7 +33,7 @@ public static class NodeGeometryExtensions
     {
         if (self.Type == NodeType.Neck) // neck normal is meant normal to existing grain boundary
         {
-            return self.Upper is GrainBoundaryNode
+            return self.Upper.Type == NodeType.GrainBoundary
                 ? new ToUpperToLower<Angle>(HalfOfPi, ThreeHalfsOfPi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower)
                 : new ToUpperToLower<Angle>(ThreeHalfsOfPi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower, HalfOfPi);
         }
@@ -46,7 +46,7 @@ public static class NodeGeometryExtensions
     {
         if (self.Type is NodeType.Neck) // neck tangent is meant tangential to existing grain boundary
         {
-            return self.Upper is GrainBoundaryNode
+            return self.Upper.Type == NodeType.GrainBoundary
                 ? new ToUpperToLower<Angle>(0, Pi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower)
                 : new ToUpperToLower<Angle>(Pi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower, 0);
         }

--- a/RefraSin.ParticleModel/NodeGeometryExtensions.cs
+++ b/RefraSin.ParticleModel/NodeGeometryExtensions.cs
@@ -1,6 +1,7 @@
 using RefraSin.Coordinates;
 using RefraSin.Coordinates.Helpers;
 using static System.Math;
+using static RefraSin.Coordinates.Constants;
 
 namespace RefraSin.ParticleModel;
 
@@ -30,12 +31,26 @@ public static class NodeGeometryExtensions
 
     public static ToUpperToLower<Angle> SurfaceNormalAngle(this INodeGeometry self)
     {
+        if (self.Type == NodeType.Neck) // neck normal is meant normal to existing grain boundary
+        {
+            return self.Upper is GrainBoundaryNode
+                ? new ToUpperToLower<Angle>(HalfOfPi, ThreeHalfsOfPi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower)
+                : new ToUpperToLower<Angle>(ThreeHalfsOfPi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower, HalfOfPi);
+        }
+
         var angle = PI - 0.5 * (self.SurfaceRadiusAngle.ToUpper + self.SurfaceRadiusAngle.ToLower);
         return new ToUpperToLower<Angle>(angle, angle);
     }
 
     public static ToUpperToLower<Angle> SurfaceTangentAngle(this INodeGeometry self)
     {
+        if (self.Type is NodeType.Neck) // neck tangent is meant tangential to existing grain boundary
+        {
+            return self.Upper is GrainBoundaryNode
+                ? new ToUpperToLower<Angle>(0, Pi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower)
+                : new ToUpperToLower<Angle>(Pi - self.SurfaceRadiusAngle.ToUpper - self.SurfaceRadiusAngle.ToLower, 0);
+        }
+
         var angle = PI / 2 - 0.5 * (self.SurfaceRadiusAngle.ToUpper + self.SurfaceRadiusAngle.ToLower);
         return new ToUpperToLower<Angle>(angle, angle);
     }

--- a/RefraSin.ParticleModel/NodeType.cs
+++ b/RefraSin.ParticleModel/NodeType.cs
@@ -2,7 +2,7 @@ namespace RefraSin.ParticleModel;
 
 public enum NodeType
 {
-    SurfaceNode,
-    GrainBoundaryNode,
-    NeckNode
+    Surface,
+    GrainBoundary,
+    Neck
 }

--- a/RefraSin.ParticleModel/Particle.cs
+++ b/RefraSin.ParticleModel/Particle.cs
@@ -25,10 +25,8 @@ public class Particle : IParticle
         _nodes = new ReadOnlyParticleSurface<Node>(
             nodes.Select(node => node switch
             {
-                INeckNode neckNode                   => new NeckNode(neckNode),
-                IGrainBoundaryNode grainBoundaryNode => new GrainBoundaryNode(grainBoundaryNode),
-                ISurfaceNode surfaceNode             => new SurfaceNode(surfaceNode),
-                _                                    => new Node(node)
+                INodeGeometry nodeGeometry => new NodeGeometry(nodeGeometry),
+                _                          => new NodeGeometry(node, this)
             })
         );
     }

--- a/RefraSin.ParticleModel/Particle.cs
+++ b/RefraSin.ParticleModel/Particle.cs
@@ -6,7 +6,7 @@ namespace RefraSin.ParticleModel;
 
 public class Particle : IParticle
 {
-    private readonly ReadOnlyParticleSurface<Node> _nodes;
+    private readonly ReadOnlyParticleSurface<INodeGeometry> _nodes;
 
     public Particle(IParticle template) : this(
         template.Id,
@@ -22,7 +22,7 @@ public class Particle : IParticle
         CenterCoordinates = centerCoordinates;
         RotationAngle = rotationAngle;
         MaterialId = materialId;
-        _nodes = new ReadOnlyParticleSurface<Node>(
+        _nodes = new ReadOnlyParticleSurface<INodeGeometry>(
             nodes.Select(node => node switch
             {
                 INodeGeometry nodeGeometry => new NodeGeometry(nodeGeometry),
@@ -32,9 +32,7 @@ public class Particle : IParticle
     }
 
     /// <inheritdoc cref="IParticle.Nodes"/>
-    public IReadOnlyParticleSurface<Node> Nodes => _nodes;
-
-    IReadOnlyParticleSurface<INode> IParticle.Nodes => Nodes;
+    public IReadOnlyParticleSurface<INodeGeometry> Nodes => _nodes;
 
     public Guid Id { get; }
     public AbsolutePoint CenterCoordinates { get; }

--- a/RefraSin.ParticleModel/ParticleFactories/ShapeFunctionParticleFactory.cs
+++ b/RefraSin.ParticleModel/ParticleFactories/ShapeFunctionParticleFactory.cs
@@ -56,7 +56,7 @@ public class ShapeFunctionParticleFactory : IParticleFactory
                     Guid.NewGuid(),
                     particleId,
                     new PolarPoint(t.First, t.Second),
-                    NodeType.SurfaceNode
+                    NodeType.Surface
                 )
             ).ToArray()
         );

--- a/RefraSin.ParticleModel/SurfaceNode.cs
+++ b/RefraSin.ParticleModel/SurfaceNode.cs
@@ -9,7 +9,7 @@ namespace RefraSin.ParticleModel;
 /// </summary>
 public record SurfaceNode(
     Guid Id,
-    Guid ParticleId,
+    IParticle Particle,
     PolarPoint Coordinates,
     AbsolutePoint AbsoluteCoordinates,
     ToUpperToLower<double> SurfaceDistance,
@@ -22,11 +22,11 @@ public record SurfaceNode(
     NormalTangential<double> VolumeGradient,
     ToUpperToLower<double> SurfaceEnergy,
     ToUpperToLower<double> SurfaceDiffusionCoefficient
-   ) : Node(Id, ParticleId, Coordinates, NodeType.SurfaceNode), ISurfaceNode
+   ) : Node(Id, Particle.Id, Coordinates, NodeType.Surface), ISurfaceNode
 {
     public SurfaceNode(ISurfaceNode template) : this(
         template.Id,
-        template.ParticleId,
+        template.Particle,
         template.Coordinates,
         template.AbsoluteCoordinates,
         template.SurfaceDistance,

--- a/RefraSin.TEPSolver.Test/TwoParticleTest.cs
+++ b/RefraSin.TEPSolver.Test/TwoParticleTest.cs
@@ -41,19 +41,19 @@ public class TwoParticleTest
                         Guid.NewGuid(),
                         baseParticle1.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, -initialNeck)),
-                        NodeType.NeckNode
+                        NodeType.Neck
                     ),
                     new Node(
                         Guid.NewGuid(),
                         baseParticle1.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, 0)),
-                        NodeType.GrainBoundaryNode
+                        NodeType.GrainBoundary
                     ),
                     new Node(
                         Guid.NewGuid(),
                         baseParticle1.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, initialNeck)),
-                        NodeType.NeckNode
+                        NodeType.Neck
                     ),
                 }
             )
@@ -79,19 +79,19 @@ public class TwoParticleTest
                         Guid.NewGuid(),
                         baseParticle2.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, -initialNeck)),
-                        NodeType.NeckNode
+                        NodeType.Neck
                     ),
                     new Node(
                         Guid.NewGuid(),
                         baseParticle2.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, 0)),
-                        NodeType.GrainBoundaryNode
+                        NodeType.GrainBoundary
                     ),
                     new Node(
                         Guid.NewGuid(),
                         baseParticle2.Id,
                         new PolarPoint(new AbsolutePoint(120e-6, initialNeck)),
-                        NodeType.NeckNode
+                        NodeType.Neck
                     ),
                 }
             )

--- a/RefraSin.TEPSolver/ParticleModel/GrainBoundaryNode.cs
+++ b/RefraSin.TEPSolver/ParticleModel/GrainBoundaryNode.cs
@@ -19,7 +19,7 @@ public class GrainBoundaryNode : ContactNodeBase<GrainBoundaryNode>, IGrainBound
         solverSession, contactedNodeId, contactedParticleId) { }
 
     /// <inheritdoc />
-    public override NodeType Type => NodeType.GrainBoundaryNode;
+    public override NodeType Type => NodeType.GrainBoundary;
 
     /// <inheritdoc />
     public override ToUpperToLower<double> SurfaceEnergy => _surfaceEnergy ??= new ToUpperToLower<double>(

--- a/RefraSin.TEPSolver/ParticleModel/NeckNode.cs
+++ b/RefraSin.TEPSolver/ParticleModel/NeckNode.cs
@@ -38,16 +38,6 @@ public class NeckNode : ContactNodeBase<NeckNode>, INeckNode
     private ToUpperToLower<double>? _surfaceDiffusionCoefficient;
 
     /// <inheritdoc />
-    public override ToUpperToLower<Angle> SurfaceNormalAngle => _surfaceNormalAngle ??= Upper is GrainBoundaryNode
-        ? new ToUpperToLower<Angle>(HalfOfPi, ThreeHalfsOfPi - SurfaceRadiusAngle.ToUpper - SurfaceRadiusAngle.ToLower)
-        : new ToUpperToLower<Angle>(ThreeHalfsOfPi - SurfaceRadiusAngle.ToUpper - SurfaceRadiusAngle.ToLower, HalfOfPi);
-
-    /// <inheritdoc />
-    public override ToUpperToLower<Angle> SurfaceTangentAngle => _surfaceTangentAngle ??= Upper is GrainBoundaryNode
-        ? new ToUpperToLower<Angle>(0, Pi - SurfaceRadiusAngle.ToUpper - SurfaceRadiusAngle.ToLower)
-        : new ToUpperToLower<Angle>(Pi - SurfaceRadiusAngle.ToUpper - SurfaceRadiusAngle.ToLower, 0);
-
-    /// <inheritdoc />
     public override NodeBase ApplyTimeStep(StepVector stepVector, double timeStepWidth, Particle particle)
     {
         var normalDisplacement = new PolarVector(SurfaceRadiusAngle.ToUpper + SurfaceNormalAngle.ToUpper,

--- a/RefraSin.TEPSolver/ParticleModel/NeckNode.cs
+++ b/RefraSin.TEPSolver/ParticleModel/NeckNode.cs
@@ -20,7 +20,7 @@ public class NeckNode : ContactNodeBase<NeckNode>, INeckNode
         solverSession, contactedNodeId, contactedParticleId) { }
 
     /// <inheritdoc />
-    public override NodeType Type => NodeType.NeckNode;
+    public override NodeType Type => NodeType.Neck;
 
     public override ToUpperToLower<double> SurfaceEnergy => _surfaceEnergy ??= new ToUpperToLower<double>(
         Upper.SurfaceEnergy.ToLower,

--- a/RefraSin.TEPSolver/ParticleModel/NodeBase.cs
+++ b/RefraSin.TEPSolver/ParticleModel/NodeBase.cs
@@ -90,72 +90,38 @@ public abstract class NodeBase : INode, INodeGeometry, INodeGradients, INodeMate
     /// <summary>
     ///     Winkeldistanz zu den Nachbarknoten (Größe des kürzesten Winkels).
     /// </summary>
-    public ToUpperToLower<Angle> AngleDistance => _angleDistance ??= new ToUpperToLower<Angle>(
-        Coordinates.AngleTo(Upper.Coordinates),
-        Coordinates.AngleTo(Lower.Coordinates)
-    );
+    public ToUpperToLower<Angle> AngleDistance => _angleDistance ??= this.AngleDistance();
 
     private ToUpperToLower<Angle>? _angleDistance;
 
     /// <summary>
     ///     Distanz zu den Nachbarknoten (Länge der Verbindungsgeraden).
     /// </summary>
-    public ToUpperToLower<double> SurfaceDistance => _surfaceDistance ??= new ToUpperToLower<double>(
-        CosLaw.C(Upper.Coordinates.R, Coordinates.R, AngleDistance.ToUpper),
-        CosLaw.C(Lower.Coordinates.R, Coordinates.R, AngleDistance.ToLower)
-    );
+    public ToUpperToLower<double> SurfaceDistance => _surfaceDistance ??= this.SurfaceDistance();
 
     private ToUpperToLower<double>? _surfaceDistance;
 
     /// <summary>
     ///     Distanz zu den Nachbarknoten (Länge der Verbindungsgeraden).
     /// </summary>
-    public ToUpperToLower<Angle> SurfaceRadiusAngle => _surfaceRadiusAngle ??= new ToUpperToLower<Angle>(
-        CosLaw.Gamma(SurfaceDistance.ToUpper, Coordinates.R, Upper.Coordinates.R),
-        CosLaw.Gamma(SurfaceDistance.ToLower, Coordinates.R, Lower.Coordinates.R)
-    );
+    public ToUpperToLower<Angle> SurfaceRadiusAngle => _surfaceRadiusAngle ??= this.SurfaceRadiusAngle();
 
     private ToUpperToLower<Angle>? _surfaceRadiusAngle;
 
     /// <summary>
     ///     Gesamtes Volumen der an den Knoten angrenzenden Elemente.
     /// </summary>
-    public ToUpperToLower<double> Volume => _volume ??= new ToUpperToLower<double>(
-        0.5 * Coordinates.R * Upper.Coordinates.R * Sin(AngleDistance.ToUpper),
-        0.5 * Coordinates.R * Lower.Coordinates.R * Sin(AngleDistance.ToLower)
-    );
-
+    public ToUpperToLower<double> Volume => _volume ??= this.Volume();
+    
     private ToUpperToLower<double>? _volume;
 
-    public virtual ToUpperToLower<Angle> SurfaceNormalAngle
-    {
-        get
-        {
-            if (_surfaceNormalAngle != null) return _surfaceNormalAngle.Value;
+    public virtual ToUpperToLower<Angle> SurfaceNormalAngle => _surfaceNormalAngle ??= this.SurfaceNormalAngle();
 
-            var angle = PI - 0.5 * (SurfaceRadiusAngle.ToUpper + SurfaceRadiusAngle.ToLower);
-            _surfaceNormalAngle = new ToUpperToLower<Angle>(angle, angle);
+    private ToUpperToLower<Angle>? _surfaceNormalAngle;
 
-            return _surfaceNormalAngle.Value;
-        }
-    }
+    public virtual ToUpperToLower<Angle> SurfaceTangentAngle => _surfaceTangentAngle ??= this.SurfaceTangentAngle();
 
-    protected ToUpperToLower<Angle>? _surfaceNormalAngle;
-
-    public virtual ToUpperToLower<Angle> SurfaceTangentAngle
-    {
-        get
-        {
-            if (_surfaceTangentAngle != null) return _surfaceTangentAngle.Value;
-
-            var angle = PI / 2 - 0.5 * (SurfaceRadiusAngle.ToUpper + SurfaceRadiusAngle.ToLower);
-            _surfaceTangentAngle = new ToUpperToLower<Angle>(angle, angle);
-
-            return _surfaceTangentAngle.Value;
-        }
-    }
-
-    protected ToUpperToLower<Angle>? _surfaceTangentAngle;
+    private ToUpperToLower<Angle>? _surfaceTangentAngle;
 
     /// <inheritdoc />
     public abstract ToUpperToLower<double> SurfaceEnergy { get; }

--- a/RefraSin.TEPSolver/ParticleModel/NodeBase.cs
+++ b/RefraSin.TEPSolver/ParticleModel/NodeBase.cs
@@ -51,6 +51,8 @@ public abstract class NodeBase : INode, INodeGeometry, INodeGradients, INodeMate
     /// </summary>
     public Particle Particle { get; }
 
+    IParticle INodeNeighbors.Particle => Particle;
+
     /// <inheritdoc />
     public Guid ParticleId => Particle.Id;
 

--- a/RefraSin.TEPSolver/ParticleModel/Particle.cs
+++ b/RefraSin.TEPSolver/ParticleModel/Particle.cs
@@ -151,7 +151,7 @@ public class Particle : IParticle
 
     public IReadOnlyParticleSurface<NodeBase> Nodes => _nodes;
 
-    IReadOnlyParticleSurface<INode> IParticle.Nodes => Nodes;
+    IReadOnlyParticleSurface<INodeGeometry> IParticle.Nodes => Nodes;
 
     /// <summary>
     /// Reference to the current solver session.

--- a/RefraSin.TEPSolver/ParticleModel/Particle.cs
+++ b/RefraSin.TEPSolver/ParticleModel/Particle.cs
@@ -66,9 +66,9 @@ public class Particle : IParticle
                     INeckNode neckNode => new NeckNode(neckNode, this, solverSession),
                     IGrainBoundaryNode grainBoundaryNode
                         => new GrainBoundaryNode(grainBoundaryNode, this, solverSession),
-                    { Type: NodeType.GrainBoundaryNode }
+                    { Type: NodeType.GrainBoundary }
                         => new GrainBoundaryNode(node, this, solverSession),
-                    { Type: NodeType.NeckNode } => new NeckNode(node, this, solverSession),
+                    { Type: NodeType.Neck } => new NeckNode(node, this, solverSession),
                     _                           => (NodeBase)new SurfaceNode(node, this, solverSession),
                 }
             )

--- a/RefraSin.TEPSolver/ParticleModel/SurfaceNode.cs
+++ b/RefraSin.TEPSolver/ParticleModel/SurfaceNode.cs
@@ -16,7 +16,7 @@ public class SurfaceNode : NodeBase, ISurfaceNode
     private SurfaceNode(Guid id, double r, Angle phi, Particle particle, ISolverSession solverSession) : base(id, r, phi, particle, solverSession) { }
 
     /// <inheritdoc />
-    public override NodeType Type => NodeType.SurfaceNode;
+    public override NodeType Type => NodeType.Surface;
 
     /// <inheritdoc />
     public override ToUpperToLower<double> SurfaceEnergy => _surfaceEnergy ??= new ToUpperToLower<double>(


### PR DESCRIPTION
Make geometry computable on non-solver nodes also for later use in remeshing. 
Implemented via `INodeGeometry` interface with default property implementations and accompanying extension methods. 